### PR TITLE
Updates

### DIFF
--- a/lib/localio/localizable_writer.rb
+++ b/lib/localio/localizable_writer.rb
@@ -3,6 +3,7 @@ require 'localio/writers/ios_writer'
 require 'localio/writers/swift_writer'
 require 'localio/writers/json_writer'
 require 'localio/writers/rails_writer'
+require 'localio/writers/rails_nested_writer'
 require 'localio/writers/java_properties_writer'
 require 'localio/writers/resx_writer'
 
@@ -19,6 +20,8 @@ module LocalizableWriter
         JsonWriter.write languages, terms, path, formatter, options
       when :rails
         RailsWriter.write languages, terms, path, formatter, options
+      when :rails_nested
+        RailsNestedWriter.write languages, terms, path, formatter, options
       when :java_properties
         JavaPropertiesWriter.write languages, terms, path, formatter, options
       when :resx

--- a/lib/localio/segment.rb
+++ b/lib/localio/segment.rb
@@ -1,14 +1,19 @@
 class Segment
 
-  attr_accessor :key, :translation, :language
+  attr_accessor :key, :translation, :language, :nested
 
   def initialize(key, translation, language)
     @key = key
     @translation = translation.to_s.replace_escaped
     @language = language
+    @nested = []
   end
 
   def is_comment?
     @key == nil
+  end
+
+  def with_nesting?
+    !@nested.empty?
   end
 end

--- a/lib/localio/segment.rb
+++ b/lib/localio/segment.rb
@@ -4,7 +4,7 @@ class Segment
 
   def initialize(key, translation, language)
     @key = key
-    @translation = translation.replace_escaped
+    @translation = translation.to_s.replace_escaped
     @language = language
   end
 

--- a/lib/localio/string_helper.rb
+++ b/lib/localio/string_helper.rb
@@ -27,6 +27,10 @@ class String
         downcase
   end
 
+  def escape
+    self.dump[1..-2]
+  end
+
   def strip_tag
     self.gsub(/^[\[][a-z][\]]/, '')
   end
@@ -34,7 +38,7 @@ class String
   def space_to_underscore
     self.gsub(' ', '_')
   end
-  
+
   def replace_escaped
     self.gsub("`+", "+").gsub("`=","=").gsub("\\+", "+").gsub("\\=","=")
   end

--- a/lib/localio/templates/rails_nested_localizable.erb
+++ b/lib/localio/templates/rails_nested_localizable.erb
@@ -1,0 +1,32 @@
+<%
+  def executable(term, nesting=0, lines=[])
+    default_indent = "  ".freeze
+    indent = default_indent * nesting + default_indent
+
+    if term.with_nesting?
+      lines << "#{indent}#{term.key}:"
+
+      term.nested.each do |_term|
+        executable(_term, nesting + 1, lines)
+      end
+    else
+      lines << "#{indent}#{term.key}: \"#{term.translation.escape}\""
+    end
+
+    return lines.join("\n")
+  end
+%>
+
+# Localizable created with localio. DO NOT MODIFY.
+#
+# Language: <%= @language %>
+
+<%= @language %>:
+<%
+  @segments.each do |term|
+    if term.is_comment? %>
+# <%= term.translation %>
+
+<%  else %><%= executable(term) %>
+<%  end
+  end %>

--- a/lib/localio/term.rb
+++ b/lib/localio/term.rb
@@ -1,5 +1,5 @@
 class Term
-
+  COMMENT_MATCHER = /^\[comment\]\d*/
   attr_accessor :values, :keyword
 
   def initialize(keyword)
@@ -8,7 +8,6 @@ class Term
   end
 
   def is_comment?
-    @keyword.downcase == '[comment]'
+    @keyword.downcase.match(COMMENT_MATCHER)
   end
-
 end

--- a/lib/localio/writers/rails_nested_writer.rb
+++ b/lib/localio/writers/rails_nested_writer.rb
@@ -1,0 +1,60 @@
+require 'pry'
+require 'localio/template_handler'
+require 'localio/segments_list_holder'
+require 'localio/segment'
+require 'localio/formatter'
+
+class RailsNestedWriter
+  DEFAULT_SEPARATOR = ' '.freeze
+
+  def self.write(languages, terms, path, formatter, options)
+    puts 'Writing Rails YAML translations...'
+
+    @nesting_separator = options[:separator] || DEFAULT_SEPARATOR
+    @key_formatter = formatter
+
+    languages.keys.each do |lang|
+      @lang = lang
+      segments_holder = SegmentsListHolder.new(lang)
+
+      @segments = segments_holder.segments
+      prepare_segments!(terms)
+
+      TemplateHandler.process_template 'rails_localizable.erb', path, "#{lang}.yml", segments_holder
+      puts " > #{lang.yellow}"
+    end
+  end
+
+  private
+
+  def self.rails_key_formatter(key)
+    key.space_to_underscore.strip_tag.downcase
+  end
+
+  def self.prepare_segments!(terms, deep=0, root=nil)
+    gterms = terms.group_by{ |t| split_key(t.keyword)[0..deep] }
+    segment_list = root.nil? ? @segments : root.nested
+
+    gterms.each do |_keys, _terms|
+      if _terms.size == 1 && _keys.size == split_key(_terms[0].keyword).size
+        key = _terms[0].is_comment? ? nil : split_key(_terms[0].keyword).last
+        add_segment(key, _terms[0].values[@lang], segment_list)
+      else
+        key = _keys[0..deep].last
+        segment = add_segment(key, nil, segment_list)
+        prepare_segments!(_terms, deep + 1, segment)
+      end
+    end
+  end
+
+  def self.split_key(key)
+    key.split(@nesting_separator)
+  end
+
+  def self.add_segment(key, translation, segments)
+    k = Formatter.format(key, @key_formatter, method(:rails_key_formatter))
+    segment = Segment.new(k, translation, @lang)
+    segments << segment
+    segment
+  end
+end

--- a/lib/localio/writers/rails_nested_writer.rb
+++ b/lib/localio/writers/rails_nested_writer.rb
@@ -12,6 +12,7 @@ class RailsNestedWriter
 
     @nesting_separator = options[:separator] || DEFAULT_SEPARATOR
     @key_formatter = formatter
+    prepare_commented_terms!(terms)
 
     languages.keys.each do |lang|
       @lang = lang
@@ -52,9 +53,13 @@ class RailsNestedWriter
   end
 
   def self.add_segment(key, translation, segments)
-    k = Formatter.format(key, @key_formatter, method(:rails_key_formatter))
+    k = Formatter.format(key, @key_formatter, method(:rails_key_formatter)) unless key.nil?
     segment = Segment.new(k, translation, @lang)
     segments << segment
     segment
+  end
+
+  def self.prepare_commented_terms!(terms)
+    terms.select(&:is_comment?).each_with_index{ |t, index| t.keyword = t.keyword + index.to_s }
   end
 end

--- a/lib/localio/writers/rails_nested_writer.rb
+++ b/lib/localio/writers/rails_nested_writer.rb
@@ -20,7 +20,7 @@ class RailsNestedWriter
       @segments = segments_holder.segments
       prepare_segments!(terms)
 
-      TemplateHandler.process_template 'rails_localizable.erb', path, "#{lang}.yml", segments_holder
+      TemplateHandler.process_template 'rails_nested_localizable.erb', path, "#{lang}.yml", segments_holder
       puts " > #{lang.yellow}"
     end
   end


### PR DESCRIPTION
Because existing writer for Rails (.yml) localization generates the flat structure like:
``` key: value ```
And standard approach for I18n is usage of .yml file with the nested structure.
So that  new writer for rails localization with nesting consideration was added.
locfile example:
```
platform :rails_nested,
               :separator => ' '

output_path './config/locales/backend/rails'

source :xls,
       :path => 'rails_translations.xls',
       :sheet => 0

```

rails_nested - new writer name
separator - separator to be used for detect nested keys from composed flat key like:
``` 
activerecord errors models model_name attributes attribute_name invalid

```
