### PR TITLE
Add ability to parse arrays of values.

### DIFF
--- a/lib/localio/segment.rb
+++ b/lib/localio/segment.rb
@@ -2,9 +2,9 @@ class Segment
 
   attr_accessor :key, :translation, :language, :nested
 
-  def initialize(key, translation, language)
+  def initialize(key, translation, language, options={})
     @key = key
-    @translation = translation.to_s.replace_escaped
+    @translation = options[:raw_translation] && translation || translation.to_s.replace_escaped
     @language = language
     @nested = []
   end

--- a/lib/localio/templates/rails_nested_localizable.erb
+++ b/lib/localio/templates/rails_nested_localizable.erb
@@ -10,7 +10,16 @@
         executable(_term, nesting + 1, lines)
       end
     else
-      lines << "#{indent}#{term.key}: \"#{term.translation}\""
+      if term.translation.is_a?(Array)
+        lines << "#{indent}#{term.key}:"
+        val_indent = indent + default_indent
+
+        term.translation.each do |val|
+          lines << "#{val_indent}- \"#{val}\""
+        end
+      else
+        lines << "#{indent}#{term.key}: \"#{term.translation}\""
+      end
     end
 
     return lines.join("\n")

--- a/lib/localio/writers/rails_nested_writer.rb
+++ b/lib/localio/writers/rails_nested_writer.rb
@@ -5,11 +5,15 @@ require 'localio/formatter'
 
 class RailsNestedWriter
   DEFAULT_SEPARATOR = ' '.freeze
+  DEFAULT_A_VALUE_MATCHER = /^array\((?<array>.+)\)/.freeze
+  DEFAULT_A_VALUE_SPLITTER = ', '.freeze
 
   def self.write(languages, terms, path, formatter, options)
     puts 'Writing Rails YAML translations...'
 
     @nesting_separator = options[:separator] || DEFAULT_SEPARATOR
+    @array_value_matcher = options[:array_value_matcher] || DEFAULT_A_VALUE_MATCHER
+    @array_value_splitter = options[:array_value_splitter] || DEFAULT_A_VALUE_SPLITTER
     @key_formatter = formatter
     prepare_commented_terms!(terms)
 
@@ -53,7 +57,12 @@ class RailsNestedWriter
 
   def self.add_segment(key, translation, segments)
     k = Formatter.format(key, @key_formatter, method(:rails_key_formatter)) unless key.nil?
-    segment = Segment.new(k, translation, @lang)
+
+    a_matched = translation.to_s.match(@array_value_matcher)
+
+    trs = a_matched && a_matched[:array].split(@array_value_splitter) || translation
+
+    segment = Segment.new(k, trs, @lang, raw_translation: trs.is_a?(Array))
     segments << segment
     segment
   end


### PR DESCRIPTION
YAML for rails allows to store values as an array format like:
``` ruby
month_names: [null, January, February, March, April, May, June, July, August, September, October, November, December]
```

or

``` ruby
    abbr_month_names:
      - null
      - Jan
      - Feb
      - Mar
      - Apr
      - May
      - Jun
      - Jul
      - Aug
      - Sep
      - Oct
      - Nov
      - Dec
```

Functionality was extended to handle these values. So you just need to chose in which format "array of values" will be store in XLS.

Default formatter:

```
array(, Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec)
```
You can use the own one by adding extra options to ``` platform_options  ``` :
 - array_value_matcher - reg expression to detect string to be splitted to array
 - array_value_splitter - splitting condition

But please note that ``` array_value_matcher  ``` should contain regexp named group with the name "array" like ``` (?<array>.+)  ```
for example these are defaults:

```
:array_value_matcher => /^array\((?<array>.+)\)/
:array_value_splitter => ', '
```
Functionality is available for ``` rails_nested  ``` platform for now.